### PR TITLE
Move QuestionTableContext up in the Compoenent Hierachy

### DIFF
--- a/frontend/api/collab/index.ts
+++ b/frontend/api/collab/index.ts
@@ -4,12 +4,12 @@ import { getActiveSessionsPath, getRoute } from "../routes";
 import { GetActiveSessionsResponse } from "./types";
 
 export async function getActiveSessions(
-  userId: string
+  userId: string,
 ): Promise<GetActiveSessionsResponse> {
   const path = getRoute(getActiveSessionsPath(userId), false);
   const res = await fetch(path, {
     method: HttpMethod.GET,
-    headers: jsonRequestHeaders
+    headers: jsonRequestHeaders,
   });
   if (!res.ok) {
     throw new RequestError(res);

--- a/frontend/api/collab/types.ts
+++ b/frontend/api/collab/types.ts
@@ -3,5 +3,5 @@ export interface GetActiveSessionsResponse {
     otherUser: string;
     wsUrl: string;
     questionId: number;
-  } []
-};
+  }[];
+}

--- a/frontend/components/ActiveSessions/index.tsx
+++ b/frontend/components/ActiveSessions/index.tsx
@@ -68,10 +68,7 @@ const ActiveSessions = () => {
         const data = activeSessions.map((s) => ({
           otherUser: userDetails[s.otherUser],
           question: questionDetails[s.questionId],
-          sessionUrl: getEditorPath(
-            s.questionId,
-            s.wsUrl
-          ),
+          sessionUrl: getEditorPath(s.questionId, s.wsUrl),
         }));
         return data;
       }

--- a/frontend/components/Editor/CodeWindow/index.tsx
+++ b/frontend/components/Editor/CodeWindow/index.tsx
@@ -489,11 +489,7 @@ export default function CodeWindow(props: CodeWindowProps) {
                   Next Question
                 </Button>
               ) : null}
-              <Button
-                onClick={initateExitMyself}
-                size="sm"
-                color="default"
-              >
+              <Button onClick={initateExitMyself} size="sm" color="default">
                 Exit
               </Button>
             </div>

--- a/frontend/components/Editor/MessageWindow/index.tsx
+++ b/frontend/components/Editor/MessageWindow/index.tsx
@@ -122,9 +122,7 @@ export default function MessageWindow(props: MessageWindowProps) {
         <Input
           placeholder="Send a message..."
           labelPlacement="outside"
-          endContent={
-            <SendHorizontal />
-          }
+          endContent={<SendHorizontal />}
           value={messageValue}
           onInput={(e) => setMessageValue(e.target.value)}
           onKeyUp={onKeyUp}

--- a/frontend/components/Editor/constants.ts
+++ b/frontend/components/Editor/constants.ts
@@ -57,5 +57,5 @@ export const CLASSNAME_PARTNER_MESSAGE =
   "max-w-[90%] self-start bg-gray-200 text-black rounded-r-md rounded-bl-md py-1 px-3";
 
 export type WSMessageType = {
-  data: string,
-}
+  data: string;
+};

--- a/frontend/components/MatchingUI/cards/TimeoutCard.tsx
+++ b/frontend/components/MatchingUI/cards/TimeoutCard.tsx
@@ -13,9 +13,7 @@ const TimeoutCard = () => {
         <Button color="secondary" onClick={onRetry}>
           Try again
         </Button>
-        <Button onClick={onClose}>
-          Cancel
-        </Button>
+        <Button onClick={onClose}>Cancel</Button>
       </ModalBody>
     </>
   );

--- a/frontend/components/QuestionDescription/Menubar.tsx
+++ b/frontend/components/QuestionDescription/Menubar.tsx
@@ -118,7 +118,9 @@ const Menubar = ({ editor }: MenubarProps) => {
           h6
         </Button>
         <Button
-          onClick={() => editor.chain().focus().unsetSuperscript().toggleSubscript().run()}
+          onClick={() =>
+            editor.chain().focus().unsetSuperscript().toggleSubscript().run()
+          }
           size="sm"
           variant={editor.isActive("subscript") ? "solid" : "bordered"}
           color="secondary"
@@ -129,7 +131,9 @@ const Menubar = ({ editor }: MenubarProps) => {
           </p>
         </Button>
         <Button
-          onClick={() => editor.chain().focus().unsetSubscript().toggleSuperscript().run()}
+          onClick={() =>
+            editor.chain().focus().unsetSubscript().toggleSuperscript().run()
+          }
           size="sm"
           variant={editor.isActive("superscript") ? "solid" : "bordered"}
           color="secondary"

--- a/frontend/components/QuestionDescription/index.tsx
+++ b/frontend/components/QuestionDescription/index.tsx
@@ -5,8 +5,8 @@ import ListItem from "@tiptap/extension-list-item";
 import TextStyle from "@tiptap/extension-text-style";
 import StarterKit from "@tiptap/starter-kit";
 import Typography from "@tiptap/extension-typography";
-import Superscript from '@tiptap/extension-superscript';
-import Subscript from '@tiptap/extension-subscript';
+import Superscript from "@tiptap/extension-superscript";
+import Subscript from "@tiptap/extension-subscript";
 import { TipTapCustomImage } from "@/components/QuestionDescription/TipTapCustomImage";
 import { cn } from "@nextui-org/react";
 
@@ -48,7 +48,7 @@ export default function QuestionDescription({
       TipTapCustomImage,
       Typography,
       Superscript,
-      Subscript
+      Subscript,
     ],
     content: initialContent,
     onUpdate({ editor }) {
@@ -65,7 +65,7 @@ export default function QuestionDescription({
         className,
       )}
     >
-      {!readonly && <Menubar editor={editor}/>}
+      {!readonly && <Menubar editor={editor} />}
       <EditorContent editor={editor} className="max-h-full overflow-auto" />
     </div>
   );

--- a/frontend/components/QuestionsCard/index.tsx
+++ b/frontend/components/QuestionsCard/index.tsx
@@ -1,6 +1,5 @@
 import Card from "@/components/Card";
 import QuestionsTable from "./QuestionsTable";
-import { QuestionTableProvider } from "./QuestionsTableContext";
 
 interface QuestionsCardProps {
   userIsAdmin: boolean;
@@ -9,7 +8,7 @@ interface QuestionsCardProps {
 export default function QuestionsCard({ userIsAdmin }: QuestionsCardProps) {
   return (
     <Card className="flex-shrink-0 flex-grow">
-        <QuestionsTable userIsAdmin={userIsAdmin} />
+      <QuestionsTable userIsAdmin={userIsAdmin} />
     </Card>
   );
 }

--- a/frontend/components/QuestionsCard/index.tsx
+++ b/frontend/components/QuestionsCard/index.tsx
@@ -9,9 +9,7 @@ interface QuestionsCardProps {
 export default function QuestionsCard({ userIsAdmin }: QuestionsCardProps) {
   return (
     <Card className="flex-shrink-0 flex-grow">
-      <QuestionTableProvider>
         <QuestionsTable userIsAdmin={userIsAdmin} />
-      </QuestionTableProvider>
     </Card>
   );
 }

--- a/frontend/components/UserProfileCard/PastAttempts/AttemptsTable/config.tsx
+++ b/frontend/components/UserProfileCard/PastAttempts/AttemptsTable/config.tsx
@@ -104,12 +104,12 @@ export const COLUMN_CONFIGS: Record<ColumnKey, ColumnConfig> = {
           attempt?.otherUser ? "Attempted with a peer" : "Attempted by yourself"
         }
       >
-        <div className="relative flex justify-center">
+        <div className="relative flex">
           {attempt?.otherUser ? <FaUserFriends /> : <BsFillPersonFill />}
         </div>
       </Tooltip>
     ),
-    align: "center",
+    align: "start",
   },
 };
 

--- a/frontend/components/UserProfileCard/PieChart/index.tsx
+++ b/frontend/components/UserProfileCard/PieChart/index.tsx
@@ -24,8 +24,10 @@ const PieChart = ({ data }: { data?: User }) => {
         Question complexity breakdown
       </div>
       {attemptCount > 0 ? (
-        <div className="flex flex-col sm:flex-row lg:flex-col
-                        items-center justify-center w-full">
+        <div
+          className="flex flex-col sm:flex-row lg:flex-col
+                        items-center justify-center w-full"
+        >
           <Pie
             data={processedPieData}
             innerRadius={0.5}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -5,6 +5,7 @@ import { NextUIProvider } from "@nextui-org/react";
 import Layout from "@/components/Layout";
 import { Toaster } from "react-hot-toast";
 import { ThemeProvider } from "next-themes";
+import { QuestionTableProvider } from "@/components/QuestionsCard/QuestionsTableContext";
 
 export default function App({
   Component,
@@ -14,10 +15,12 @@ export default function App({
     <NextUIProvider>
       <SessionProvider session={session}>
         <ThemeProvider attribute="class" defaultTheme="dark">
-          <Toaster />
-          <Layout>
+          <QuestionTableProvider>
+            <Toaster />
+            <Layout>
               <Component {...pageProps} />
-          </Layout>
+            </Layout>
+          </QuestionTableProvider>
         </ThemeProvider>
       </SessionProvider>
     </NextUIProvider>

--- a/frontend/pages/api/collab/active-sessions/index.ts
+++ b/frontend/pages/api/collab/active-sessions/index.ts
@@ -14,7 +14,7 @@ export default async function handler(
   }
   const options = {
     method: "GET",
-    headers: jsonRequestHeaders
+    headers: jsonRequestHeaders,
   };
   try {
     const userId = req.query["userId"];
@@ -24,6 +24,8 @@ export default async function handler(
     const activeSessions = responseJson["activeSessions"];
     res.status(HttpStatus.OK).json({ activeSessions: activeSessions });
   } catch (e) {
-    res.status(HttpStatus.INTERNAL_SERVER_ERROR).send("Error fetching active sessions");
+    res
+      .status(HttpStatus.INTERNAL_SERVER_ERROR)
+      .send("Error fetching active sessions");
   }
 }

--- a/frontend/pages/api/questions/[questionId].ts
+++ b/frontend/pages/api/questions/[questionId].ts
@@ -1,4 +1,4 @@
-import {  HttpStatus } from "@/api/constants";
+import { HttpStatus } from "@/api/constants";
 import {
   checkIfUserIsAdmin,
   forwardRequestAndGetResponse,

--- a/frontend/pages/editor/[questionId]/index.tsx
+++ b/frontend/pages/editor/[questionId]/index.tsx
@@ -57,7 +57,10 @@ export default function EditorPage({
           <Panel defaultSize={40} minSize={25}>
             <PanelGroup direction="vertical">
               <Panel defaultSize={80}>
-                <QuestionDetailsCard question={question} className="max-h-full overflow-auto"/>
+                <QuestionDetailsCard
+                  question={question}
+                  className="max-h-full overflow-auto"
+                />
               </Panel>
               <HorizontalResizeHandle />
               <Panel>

--- a/frontend/pages/login/index.tsx
+++ b/frontend/pages/login/index.tsx
@@ -7,8 +7,6 @@ import cx from "classnames";
 import { RACING_SANS_ONE_CLASS } from "@/assets/fonts/racingSansOne";
 import Button from "@/components/Button";
 import { useAppearAnimation } from "@/hooks/useAppearAnimation";
-import { useTheme } from "next-themes";
-import { useMemo } from "react";
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const session = await getServerSession(context.req, context.res, authOptions);
@@ -29,9 +27,6 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 export default function LoginPage({
   providers,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const { theme } = useTheme();
-  const isDark = useMemo(() => theme === "dark", [theme]);
-
   return (
     <div className="h-full w-full pt-[80px] pl-[180px]">
       <div className="w-[450px] " style={{ ...useAppearAnimation() }}>
@@ -39,7 +34,7 @@ export default function LoginPage({
           className={cx(
             RACING_SANS_ONE_CLASS,
             "text-8xl pb-3",
-            isDark ? "text-brand-white" : "text-purple-800",
+            "text-brand-white dark:text-purple-800",
           )}
         >
           PeerPrep


### PR DESCRIPTION
Simple hack to get pagination data to persist across page navigation - by moving the QuestionTableContextProvider up to _app, for better UX experience. (such as when clicking into a question on page 10, when you go back, you will still be on page 10).

Submitting this PR to get a 2nd pair of eyes - namely @teoyuqi, just to check that nothing gets messed up from this hack. Based on my testing, works well. Just merge it in if its good!